### PR TITLE
Update conf variable to equal cfg

### DIFF
--- a/main.py
+++ b/main.py
@@ -124,7 +124,7 @@ def confparse():
         print("No configuration file detected.")
         exit
     source = args.mode
-    conf = cfg.get(source)
+    conf = cfg
     return conf, args
 
 def main(data, ma, protocol):


### PR DESCRIPTION
I noticed that whenever I run goonfetch, the conf variable doesn't have the proper "auth" key in it.

After looking at the confparse() function, I realized that on line 127 when conf = cfg.get(source), it reduces the conf variable to None. 

Changing conf = cfg removes the error. 

I know that there was some refactoring with cfg, but I didn't know how else to integrate my change with yours. Please let me know if there's an alternate solution.